### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update "tag" to "label" in run.log
 * When running eval with verbose, show the real matching paths instead of with placeholder and show base dir if not matching
 * Add header to annotation output and separate columns for pos and ref/alt
+* If outpath is provided, write all variant presence entries to file
 
 # 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Simplify README by removing help printout
 * Pretty print variant presence/absence
 * Update "tag" to "label" in run.log
+* When running eval with verbose, show the real matching paths instead of with placeholder
 
 # 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.0
+
+* Show total number of variants in scored comparisons
+* Simplify README by removing help printout
+
 # 1.0.4
 
 * Calculate length through END - pos + 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Show total number of variants in scored comparisons
 * Simplify README by removing help printout
-* Pretty print annotations
+* Pretty print variant presence/absence
+* Update "tag" to "label" in run.log
 
 # 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Pretty print variant presence/absence
 * Update "tag" to "label" in run.log
 * When running eval with verbose, show the real matching paths instead of with placeholder and show base dir if not matching
+* Add header to annotation output and separate columns for pos and ref/alt
 
 # 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Simplify README by removing help printout
 * Pretty print variant presence/absence
 * Update "tag" to "label" in run.log
-* When running eval with verbose, show the real matching paths instead of with placeholder
+* When running eval with verbose, show the real matching paths instead of with placeholder and show base dir if not matching
 
 # 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Show total number of variants in scored comparisons
 * Simplify README by removing help printout
+* Pretty print annotations
 
 # 1.0.4
 

--- a/README.md
+++ b/README.md
@@ -23,38 +23,10 @@ python3 main.py run \
     --label run1
 ```
 
-```{python}
-usage: main.py run [-h] [--label LABEL] --checkout CHECKOUT --base BASE
-                   --repo REPO [--start_data START_DATA] --run_type RUN_TYPE
-                   [--dry] [--skip_confirmation] [--stub] --config CONFIG
-                   [--queue QUEUE] [--nostart]
+Get more options by running:
 
-Runs a pipeline.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --label LABEL         Something for you to use to remember the run
-  --checkout CHECKOUT   Tag, commit or branch to check out in --repo
-  --base BASE     The base folder into which results folders are created
-                        following the pattern:
-                        {base}/{label}_{run_type}_{checkout})
-  --repo REPO           Path to the Git repository of the pipeline
-  --start_data START_DATA
-                        Start run from FASTQ (fq), BAM (bam) or VCF (vcf)
-                        (must be present in config)
-  --run_type RUN_TYPE   Select run type from the config (i.e. giab-single,
-                        giab-trio, seracare ...). Multiple comma-separated can
-                        be specified.
-  --dry, -n             Go through the motions, but don't execute the pipeline
-  --skip_confirmation   If not set, you will be asked before starting the
-                        pipeline run
-  --stub                Pass the -stub-run flag to the pipeline
-  --config CONFIG       Config file in INI format containing information about
-                        run types and cases
-  --queue QUEUE         Optionally specify in which queue to run (i.e. low,
-                        grace-normal etc.)
-  --nostart             Run start_nextflow_analysis.pl with nostart, printing
-                        the path to the SLURM job only
+```
+python3 main.py run --help
 ```
 
 ### Running the evaluator
@@ -68,32 +40,6 @@ python3 main.py eval \
     --comparisons default
 ```
 
-```{python}
-usage: main.py eval [-h] [--run_id1 RUN_ID1] [--run_id2 RUN_ID2] --results1
-                    RESULTS1 --results2 RESULTS2 --config CONFIG
-                    [--comparisons COMPARISONS]
-                    [--score_threshold SCORE_THRESHOLD]
-                    [--max_display MAX_DISPLAY] [--outdir OUTDIR]
-
-Takes two sets of results and generates a comparison
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --run_id1 RUN_ID1, -i1 RUN_ID1
-                        The group ID is used in some file names and can differ
-                        between runs. If not provided, it is set to the base
-                        folder name.
-  --run_id2 RUN_ID2, -i2 RUN_ID2
-                        See --run_id1 help
-  --results1 RESULTS1, -r1 RESULTS1
-  --results2 RESULTS2, -r2 RESULTS2
-  --config CONFIG       Additional configurations
-  --comparisons COMPARISONS
-                        Comma separated. Defaults to: default, run all by:
-                        file,vcf,score,score_sv,yaml
-  --score_threshold SCORE_THRESHOLD
-                        Limit score comparisons to above this threshold
-  --max_display MAX_DISPLAY
-                        Max number of top variants to print to STDOUT
-  --outdir OUTDIR       Optional output folder to store result files
+```
+python3 main.py eval --help
 ```

--- a/evaluator/annotation_utils.py
+++ b/evaluator/annotation_utils.py
@@ -13,13 +13,14 @@ class AnnotComp:
         self,
         variant_key: str,
         info_key: str,
-        variant_basic_info: str,
+        variant: ScoredVariant,
         r1_annot: str,
         r2_annot: str,
     ):
         self.variant_key = variant_key
         self.info_key = info_key
-        self.variant_basic_info = variant_basic_info
+        self.variant_pos = variant
+        self.variant = variant
         self.r1_annot = r1_annot
         self.r2_annot = r2_annot
 
@@ -116,7 +117,7 @@ def calculate_annotation_diffs(
                 annot_comp = AnnotComp(
                     variant_key,
                     shared_annot_key,
-                    variants_r1[variant_key].get_basic_info(),
+                    variants_r1[variant_key],
                     info_val_r1,
                     info_val_r2,
                 )
@@ -132,18 +133,22 @@ def get_annot_value_diff_summary(
     diffs_per_annot: Dict[str, List[AnnotComp]]
 ) -> List[str]:
 
-    output_rows = []
+    header = ["key", "number", "pos", "ref/alt", "first example"]
+    output_rows = [header]
     for info_key, annot_value_diffs in diffs_per_annot.items():
         first_differing_variant = annot_value_diffs[0]
         r1_val = first_differing_variant.r1_annot
         r2_val = first_differing_variant.r2_annot
-        variant_info = first_differing_variant.variant_basic_info
+        var = first_differing_variant.variant
+        variant_pos = f"{var.chr}:{var.pos}"
+        variant_ref_alt = f"{var.get_trunc_ref()}:{var.get_trunc_alt()}"
         example_r1 = truncate_string(r1_val, MAX_STR_LEN)
         example_r2 = truncate_string(r2_val, MAX_STR_LEN)
         row = [
             info_key,
             len(annot_value_diffs),
-            variant_info,
+            variant_pos,
+            variant_ref_alt,
             f"{example_r1} / {example_r2}",
         ]
         output_rows.append(row)

--- a/evaluator/classes.py
+++ b/evaluator/classes.py
@@ -1,6 +1,6 @@
 import gzip
 from pathlib import Path
-from typing import Dict, Optional, TextIO
+from typing import Dict, Optional, TextIO, List
 
 TRUNC_LENGTH = 30
 
@@ -71,6 +71,14 @@ class ScoredVariant:
 
     def get_basic_info(self) -> str:
         return f"{self.chr}:{self.pos} {self.get_trunc_ref()}/{self.get_trunc_alt()}"
+
+    def get_row_fields(self) -> List[str]:
+        row = [self.chr, self.pos, self.get_trunc_ref(), self.get_trunc_alt()]
+        if self.sv_length is not None:
+            row.append(str(self.sv_length))
+        if self.rank_score is not None:
+            row.append(str(self.rank_score))
+        return row
 
     def __eq__(self, other) -> bool:
         return (

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -362,8 +362,15 @@ def get_variant_presence_summary(
             )
         else:
             output.append(f"Only found in {label_r1}")
+
+        r1_table = []
         for key in sorted(list(r1_only), key=parse_var_key_for_sort)[0:max_display]:
-            output.append(str(variants_r1[key]))
+            row_fields = variants_r1[key].get_row_fields()
+            r1_table.append(row_fields)
+        pretty_rows = prettify_rows(r1_table)
+        for row in pretty_rows:
+            print(row)
+
     if len(r2_only) > 0:
         if max_display is not None:
             output.append(
@@ -371,8 +378,14 @@ def get_variant_presence_summary(
             )
         else:
             output.append(f"Only found in {label_r2}")
+
+        r2_table = []
         for key in sorted(list(r2_only), key=parse_var_key_for_sort)[0:max_display]:
-            output.append(str(variants_r2[key]))
+            row_fields = variants_r2[key].get_row_fields()
+            r2_table.append(row_fields)
+        pretty_rows = prettify_rows(r2_table)
+        for row in pretty_rows:
+            print(row)
 
     return output
 

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -16,7 +16,7 @@ import logging
 
 from evaluator.annotation_utils import compare_variant_annotation
 from util.constants import RUN_ID_PLACEHOLDER
-from util.shared_utils import load_config, prettify_rows, truncate_string
+from util.shared_utils import load_config, prettify_rows
 
 from .score_utils import get_table
 from .classes import DiffScoredVariant

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -343,7 +343,7 @@ def compare_variant_presence(
         logger.info(line)
 
     if out_path is not None:
-        summary_lines = get_variant_presence_summary(
+        full_summary_lines = get_variant_presence_summary(
             label_r1,
             label_r2,
             common,
@@ -354,7 +354,7 @@ def compare_variant_presence(
             max_display=None,
         )
         with out_path.open("w") as out_fh:
-            for line in summary_lines:
+            for line in full_summary_lines:
                 print(line, file=out_fh)
 
 

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -343,6 +343,16 @@ def compare_variant_presence(
         logger.info(line)
 
     if out_path is not None:
+        summary_lines = get_variant_presence_summary(
+            label_r1,
+            label_r2,
+            common,
+            r1_only,
+            r2_only,
+            variants_r1,
+            variants_r2,
+            max_display=None,
+        )
         with out_path.open("w") as out_fh:
             for line in summary_lines:
                 print(line, file=out_fh)

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -550,6 +550,9 @@ def print_diff_score_info(
     logger.info(
         f"Number differently scored above {score_threshold}: {len(diff_variants_above_thres)}",
     )
+    logger.info(
+        f"Total number shared variants: {len(shared_variant_keys)} (r1: {len(variants_r1)}, r2: {len(variants_r2)})",
+    )
 
     full_comparison_table = get_table(
         run_id1,

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -161,6 +161,8 @@ def main(
             config["settings"]["scored_snv"].split(","),
             r1_paths,
             r2_paths,
+            results1_dir,
+            results2_dir,
             verbose,
         )
 
@@ -200,6 +202,8 @@ def main(
             config["settings"]["scored_sv"].split(","),
             r1_paths,
             r2_paths,
+            results1_dir,
+            results2_dir,
             verbose,
         )
 
@@ -234,6 +238,8 @@ def main(
             config["settings"]["yaml"].split(","),
             r1_paths,
             r2_paths,
+            results1_dir,
+            results2_dir,
             verbose,
         )
         out_path = outdir / "yaml_diff.txt" if outdir else None
@@ -248,6 +254,8 @@ def main(
             config["settings"]["versions"].split(","),
             r1_paths,
             r2_paths,
+            results1_dir,
+            results2_dir,
             verbose,
         )
         out_path = outdir / "yaml_diff.txt" if outdir else None

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -387,7 +387,7 @@ def get_variant_presence_summary(
             r1_table.append(row_fields)
         pretty_rows = prettify_rows(r1_table)
         for row in pretty_rows:
-            print(row)
+            output.append(row)
 
     if len(r2_only) > 0:
         if max_display is not None:
@@ -403,7 +403,7 @@ def get_variant_presence_summary(
             r2_table.append(row_fields)
         pretty_rows = prettify_rows(r2_table)
         for row in pretty_rows:
-            print(row)
+            output.append(row)
 
     return output
 

--- a/evaluator/util.py
+++ b/evaluator/util.py
@@ -192,13 +192,30 @@ def get_pair_match(
     valid_patterns: List[str],
     r1_paths: List[PathObj],
     r2_paths: List[PathObj],
+    r1_base_dir: Path,
+    r2_base_dir: Path,
     verbose: bool,
 ) -> Tuple[PathObj, PathObj]:
     r1_matching = get_single_file_ending_with(valid_patterns, r1_paths)
     r2_matching = get_single_file_ending_with(valid_patterns, r2_paths)
     if verbose:
-        logger.info(f"Looking for pattern {valid_patterns}, found {r1_matching} in r1")
-        logger.info(f"Looking for pattern {valid_patterns}, found {r2_matching} in r2")
+        if r1_matching is not None:
+            logger.info(
+                f"Looking for pattern(s) {valid_patterns}, found {r1_matching.real_path} in r1"
+            )
+        else:
+            logger.info(
+                f"Looking for pattern(s) {valid_patterns}, did not match any file in {r1_base_dir}"
+            )
+
+        if r2_matching is not None:
+            logger.info(
+                f"Looking for pattern(s) {valid_patterns}, found {r2_matching.real_path} in r2"
+            )
+        else:
+            logger.info(
+                f"Looking for pattern(s) {valid_patterns}, did not match any file in {r2_base_dir}"
+            )
 
     verify_pair_exists(error_label, r1_matching, r2_matching)
     if r1_matching is None or r2_matching is None:

--- a/runner/runner.py
+++ b/runner/runner.py
@@ -215,7 +215,7 @@ def build_run_label(
 def write_run_log(
     run_log_path: Path,
     run_type: str,
-    tag: str,
+    label: str,
     checkout_str: str,
     config: ConfigParser,
     commit_hash: str,
@@ -224,7 +224,7 @@ def write_run_log(
         print("# Settings", file=out_fh)
         print(f"output dir: {run_log_path.parent}", file=out_fh)
         print(f"run type: {run_type}", file=out_fh)
-        print(f"tag: {tag}", file=out_fh)
+        print(f"run label: {label}", file=out_fh)
         print(f"checkout: {checkout_str}", file=out_fh)
         print(f"commit hash: {commit_hash}", file=out_fh)
         print("", file=out_fh)

--- a/runner/runner.py
+++ b/runner/runner.py
@@ -385,7 +385,7 @@ def start_run(
 ):
     if not dry_run:
         if not skip_confirmation:
-            pretty_command = " \\n    ".join(start_nextflow_command)
+            pretty_command = " \\\n    ".join(start_nextflow_command)
             confirmation = input(
                 f"Do you want to run the following command:\n{pretty_command}\n(y/n) "
             )

--- a/runner/runner.py
+++ b/runner/runner.py
@@ -383,11 +383,11 @@ def build_start_nextflow_analysis_cmd(
 def start_run(
     start_nextflow_command: List[str], dry_run: bool, skip_confirmation: bool
 ):
-    joined_command = " ".join(start_nextflow_command)
     if not dry_run:
         if not skip_confirmation:
+            pretty_command = " \\n    ".join(start_nextflow_command)
             confirmation = input(
-                f"Do you want to run the following command:\n{joined_command}\n(y/n) "
+                f"Do you want to run the following command:\n{pretty_command}\n(y/n) "
             )
 
             if confirmation == "y":
@@ -397,6 +397,7 @@ def start_run(
         else:
             subprocess.run(start_nextflow_command, check=True)
     else:
+        joined_command = " ".join(start_nextflow_command)
         LOG.info("(dry) " + joined_command)
 
 


### PR DESCRIPTION
Close #40 
Close #42
Close #43
Close #45
Close #47
Close #46

Changelog:

```
# 1.1.0

* Show total number of variants in scored comparisons
* Simplify README by removing help printout
* Pretty print variant presence/absence
* Update "tag" to "label" in run.log
* When running eval with verbose, show the real matching paths instead of with placeholder and show base dir if not matching
* Add header to annotation output and separate columns for pos and ref/alt
* If outpath is provided, write all variant presence entries to file (and do so with full ref/alt)
```

The most consequential change is attempting to fix the bug mentioned by @alkc in #46.